### PR TITLE
Add row editing modal

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "antd": "^5.13.1",
     "@ant-design/icons": "^5.1.0",
     "axios": "^1.5.0",
-    "recharts": "^2.7.2"
+    "recharts": "^2.7.2",
+    "dayjs": "^1.11.9"
   },
   "devDependencies": {
     "@types/react": "^18.2.0",

--- a/src/components/DataTable/index.tsx
+++ b/src/components/DataTable/index.tsx
@@ -1,4 +1,16 @@
-import { Table } from 'antd';
+import React, { useState } from 'react';
+import {
+  Table,
+  Button,
+  Modal,
+  Form,
+  Input,
+  InputNumber,
+  Select,
+  Switch,
+  DatePicker
+} from 'antd';
+import dayjs from 'dayjs';
 
 export interface Order {
   id: string;
@@ -9,15 +21,93 @@ export interface Order {
 
 interface Props {
   data: Order[];
+  onUpdate?: (order: Order) => void;
 }
 
-const columns = [
-  { title: 'Order ID', dataIndex: 'id', key: 'id' },
-  { title: 'Customer', dataIndex: 'customer', key: 'customer' },
-  { title: 'Date', dataIndex: 'date', key: 'date' },
-  { title: 'Status', dataIndex: 'status', key: 'status' }
-];
+export default function DataTable({ data, onUpdate }: Props) {
+  const [form] = Form.useForm();
+  const [editing, setEditing] = useState<Order | null>(null);
 
-export default function DataTable({ data }: Props) {
-  return <Table rowKey="id" columns={columns} dataSource={data} pagination={false} />;
+  const fieldLabels: Record<keyof Order, string> = {
+    id: 'Order ID',
+    customer: 'Customer',
+    date: 'Date',
+    status: 'Status'
+  };
+
+  const fieldTypes: Record<keyof Order, string> = {
+    id: 'text',
+    customer: 'text',
+    date: 'date',
+    status: 'select'
+  };
+
+  const statusOptions = [
+    { value: 'Pending', label: 'Pending' },
+    { value: 'Processing', label: 'Processing' },
+    { value: 'Shipped', label: 'Shipped' },
+    { value: 'Delivered', label: 'Delivered' }
+  ];
+
+  const handleEdit = (record: Order) => {
+    setEditing(record);
+    form.setFieldsValue({
+      ...record,
+      date: dayjs(record.date)
+    });
+  };
+
+  const handleSave = async () => {
+    const values = await form.validateFields();
+    const updated: Order = {
+      ...editing!,
+      ...values,
+      date: values.date.format('YYYY-MM-DD')
+    };
+    onUpdate && onUpdate(updated);
+    setEditing(null);
+  };
+
+  const columns = [
+    { title: 'Order ID', dataIndex: 'id', key: 'id' },
+    { title: 'Customer', dataIndex: 'customer', key: 'customer' },
+    { title: 'Date', dataIndex: 'date', key: 'date' },
+    { title: 'Status', dataIndex: 'status', key: 'status' },
+    {
+      title: '操作',
+      key: 'action',
+      render: (_: any, record: Order) => (
+        <Button type="link" onClick={() => handleEdit(record)}>
+          编辑
+        </Button>
+      )
+    }
+  ];
+
+  return (
+    <>
+      <Table rowKey="id" columns={columns} dataSource={data} pagination={false} />
+      <Modal
+        open={!!editing}
+        title="编辑订单"
+        onCancel={() => setEditing(null)}
+        onOk={handleSave}
+        okText="保存"
+        cancelText="取消"
+      >
+        <Form form={form} layout="vertical">
+          {editing &&
+            (Object.keys(editing) as (keyof Order)[]).map((key) => (
+              <Form.Item label={fieldLabels[key]} name={key} key={key} valuePropName={fieldTypes[key] === 'bool' ? 'checked' : 'value'}>
+                {fieldTypes[key] === 'text' && <Input />}
+                {fieldTypes[key] === 'number' && <InputNumber style={{ width: '100%' }} />}
+                {fieldTypes[key] === 'select' && <Select options={statusOptions} />}
+                {fieldTypes[key] === 'bool' && <Switch />}
+                {fieldTypes[key] === 'date' && <DatePicker style={{ width: '100%' }} />}
+              </Form.Item>
+            ))}
+        </Form>
+      </Modal>
+    </>
+  );
 }

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -11,11 +11,16 @@ import StatCard from '@/components/StatCard';
 import LineChart from '@/components/LineChart';
 import BarChart from '@/components/BarChart';
 import DataTable from '@/components/DataTable';
-import { getOrders, Order } from '@/services/api';
+import { getOrders } from '@/services/api';
+import { Order } from '@/components/DataTable';
 import { formatNumber } from '@/utils';
 
 export default function Dashboard() {
   const [orders, setOrders] = useState<Order[]>([]);
+
+  const handleUpdate = (order: Order) => {
+    setOrders((prev) => prev.map((item) => (item.id === order.id ? order : item)));
+  };
 
   useEffect(() => {
     getOrders().then(setOrders);
@@ -64,7 +69,7 @@ export default function Dashboard() {
       </Row>
 
       <div style={{ marginTop: 16 }}>
-        <DataTable data={orders} />
+        <DataTable data={orders} onUpdate={handleUpdate} />
       </div>
     </AppLayout>
   );


### PR DESCRIPTION
## Summary
- add `dayjs` dependency
- enhance `DataTable` with edit button and modal form
- update `Dashboard` to handle row updates

## Testing
- `npm run build` *(fails: cannot find modules due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6867622f58ec83328864357bea66b30a